### PR TITLE
template context

### DIFF
--- a/linaro_django_pagination/templatetags/pagination_tags.py
+++ b/linaro_django_pagination/templatetags/pagination_tags.py
@@ -40,6 +40,7 @@ from django.template import (
     TOKEN_BLOCK,
     TemplateSyntaxError,
     Variable,
+    loader,
 )
 from django.template.loader import select_template
 from django.utils.text import unescape_string_literal
@@ -185,11 +186,9 @@ class PaginateNode(Node):
         to_return = paginate(context)
         if self.template:
             template_list.insert(0, self.template)
-        t = select_template(template_list)
-        if not t:
-            return None
-        context = Context(to_return)
-        return t.render(context)
+        return loader.render_to_string(template_list, to_return, 
+            context_instance = context)
+
 
 
 def do_paginate(parser, token):


### PR DESCRIPTION
Hi

It's worth passing the whole template context to the template doing the rendering. It's useful when you need access to other variables outside the scope of the pagination. 

It would also be nice if you'd version bump it and push to pypi.

Cheers
