### PR TITLE
RFD: Reuse existing paginator?

### DIFF
--- a/linaro_django_pagination/templatetags/pagination_tags.py
+++ b/linaro_django_pagination/templatetags/pagination_tags.py
@@ -135,7 +135,8 @@ class AutoPaginateNode(Node):
         self.multiple_paginations = multiple_paginations
 
     def render(self, context):
-        if self.multiple_paginations or getattr(context, "paginator", None):
+        paginator = context.get('paginator', None)
+        if self.multiple_paginations or paginator:
             page_suffix = '_%s' % self.queryset_var
         else:
             page_suffix = ''
@@ -150,7 +151,10 @@ class AutoPaginateNode(Node):
             orphans = self.orphans
         else:
             orphans = self.orphans.resolve(context)
-        paginator = Paginator(value, paginate_by, orphans)
+        # Use existing paginator if possible, to avoid bad
+        # values for eg. num_pages
+        if paginator is None:
+            paginator = Paginator(value, paginate_by, orphans)
         try:
             request = context['request']
         except KeyError:


### PR DESCRIPTION
Issue #18 describes how pagination, especially paginator.num_pages breaks if
{% autopaginate %} is called twice in the same template.

I do not understand how the render method works, at least for now, but my troubles
seem to go away, at least for now, if I re-use the existing paginator the other time
around.

Most likely this is the intended behavior originally and not having it so was a bug,
but I can't say for sure.

Apparently there is no state magick involved, so this should be ok from a
thread-safety point of view.

Do you think think it's ok? I'd hate to break it for everyone else.
