### PR TITLE
I'm terribly sorry… (fix for #24)

### DIFF
--- a/linaro_django_pagination/templates/pagination/pagination.html
+++ b/linaro_django_pagination/templates/pagination/pagination.html
@@ -4,7 +4,7 @@
   {% block previouslink %}
   {% if page_obj.has_previous %}
   {% if disable_link_for_first_page and page_obj.previous_page_number == 1 %}
-  <a href="{{ request.path }}{{ getvars }}" class="prev">{{ previous_link_decorator|safe }}{% trans "previous" %}</a>
+  <a href="{{ request.path }}{% if getvars %}?{{ getvars|slice:"1:" }}{% endif %}" class="prev">{{ previous_link_decorator|safe }}{% trans "previous" %}</a>
   {% else %}
   <a href="?page{{ page_suffix }}={{ page_obj.previous_page_number }}{{ getvars }}" class="prev">{{ previous_link_decorator|safe }}{% trans "previous" %}</a>
   {% endif %}
@@ -22,7 +22,7 @@
   <span class="current page">{{ page }}</span>
   {% else %}
   {% if disable_link_for_first_page and page == 1 %}
-  <a href="{{ request.path }}{{ getvars }}" class="page">{{ page }}</a>
+  <a href="{{ request.path }}{% if getvars %}?{{ getvars|slice:"1:" }}{% endif %}" class="page">{{ page }}</a>
   {% else %}
   <a href="?page{{ page_suffix }}={{ page }}{{ getvars }}" class="page">{{ page }}</a>
   {% endif %}


### PR DESCRIPTION
fixes a bug caused by my previous PR (#24) and hardcoded generation of `getvars` variable.
bug description: when `disable_link_for_first_page` is true, for first page's link there was no replacing of "&" to "?" for first GET parameter, so there was 404.
i didn't rewrote `getvars` generation, thus i avoid increasing of complexity. i'll rewrote it later, if i'll be allowed to do so.
