### PR TITLE
Django 1.8 Support

### DIFF
--- a/linaro_django_pagination/templatetags/pagination_tags.py
+++ b/linaro_django_pagination/templatetags/pagination_tags.py
@@ -37,11 +37,16 @@ from django.template import (
     Context,
     Library,
     Node,
-    TOKEN_BLOCK,
     TemplateSyntaxError,
     Variable,
     loader,
 )
+
+try:
+    from django.template.base import TOKEN_BLOCK
+except ImportError:     # Django < 1.8
+    from django.template import TOKEN_BLOCK
+
 from django.template.loader import select_template
 from django.utils.text import unescape_string_literal
 


### PR DESCRIPTION
TOKEN_BLOCK was moved to django.template.base, so import error occurs like this,

```
TemplateSyntaxError: 'pagination_tags' is not a valid tag library: ImportError raised loading linaro_django_pagination.templatetags.pagination_tags: cannot import name TOKEN_BLOCK
```