### PR TITLE
Suppress RemovedInDjango19Warning

### DIFF
--- a/linaro_django_pagination/middleware.py
+++ b/linaro_django_pagination/middleware.py
@@ -35,7 +35,12 @@ def get_page(self, suffix):
     integer representing the current page.
     """
     try:
-        return int(self.REQUEST['page%s' % suffix])
+        # REQUEST is deprecated as of Django 1.7.
+        key = 'page%s' % suffix
+        value = self.POST.get(key)
+        if value is None:
+            value = self.GET.get(key)
+        return int(value)
     except (KeyError, ValueError, TypeError):
         return 1
 


### PR DESCRIPTION
request.REQUEST is deprecated as described here, https://docs.djangoproject.com/en/1.8/ref/request-response/#django.http.HttpRequest.REQUEST

