### PR TITLE
Fix xrange slice

### DIFF
--- a/linaro_django_pagination/middleware.py
+++ b/linaro_django_pagination/middleware.py
@@ -35,7 +35,12 @@ def get_page(self, suffix):
     integer representing the current page.
     """
     try:
-        return int(self.REQUEST['page%s' % suffix])
+        # REQUEST is deprecated as of Django 1.7.
+        key = 'page%s' % suffix
+        value = self.POST.get(key)
+        if value is None:
+            value = self.GET.get(key)
+        return int(value)
     except (KeyError, ValueError, TypeError):
         return 1
 

--- a/linaro_django_pagination/templatetags/pagination_tags.py
+++ b/linaro_django_pagination/templatetags/pagination_tags.py
@@ -264,7 +264,7 @@ def paginate(context, window=DEFAULT_WINDOW, margin=DEFAULT_MARGIN):
         paginator = context['paginator']
         page_obj = context['page_obj']
         page_suffix = context.get('page_suffix', '')
-        page_range = paginator.page_range
+        page_range = list(paginator.page_range)
         # Calculate the record range in the current page for display.
         records = {'first': 1 + (page_obj.number - 1) * paginator.per_page}
         records['last'] = records['first'] + paginator.per_page - 1


### PR DESCRIPTION
In Django1.9 page_range is now a generator:
https://docs.djangoproject.com/en/1.9/releases/1.9/#paginator-page-range