### PR TITLE
Django 1.10 is preparing to remove context_instance.

### DIFF
--- a/linaro_django_pagination/templatetags/pagination_tags.py
+++ b/linaro_django_pagination/templatetags/pagination_tags.py
@@ -195,9 +195,7 @@ class PaginateNode(Node):
         new_context = paginate(context)
         if self.template:
             template_list.insert(0, self.template)
-        return loader.render_to_string(template_list, new_context,
-            context_instance = context)
-
+        return loader.render_to_string(template_list, new_context)
 
 
 def do_paginate(parser, token):


### PR DESCRIPTION
Context instance is being deprecated in favor of using context
dictionaries. So resolving warnings means patching this library
for some projects, like readthedocs, which use it.

When I tested out the removal of the context_instance, things
worked. However, I'm not sure I fully understood how context_instance
was being used. So I'm not sure if there are edge cases where
removing it might effect others, despite it not having effected me.